### PR TITLE
Snackbar for long time

### DIFF
--- a/app/src/main/java/com/example/avjindersinghsekhon/minimaltodo/MainActivity.java
+++ b/app/src/main/java/com/example/avjindersinghsekhon/minimaltodo/MainActivity.java
@@ -452,7 +452,7 @@ public class MainActivity extends AppCompatActivity {
 
 //            String toShow = (mJustDeletedToDoItem.getToDoText().length()>20)?mJustDeletedToDoItem.getToDoText().substring(0, 20)+"...":mJustDeletedToDoItem.getToDoText();
             String toShow = "Todo";
-            Snackbar.make(mCoordLayout, "Deleted "+toShow,Snackbar.LENGTH_SHORT)
+            Snackbar.make(mCoordLayout, "Deleted "+toShow,Snackbar.LENGTH_LONG)
                     .setAction("UNDO", new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {


### PR DESCRIPTION
The Snackbar which app using currently has duration of LENGTH_SHORT by which Snackbar appears for very small duration. If a user accidentally deleted the Title  the user must require few second to undo the changes.So preferable choice is to use Snackbar with LENGTH_LONG which show Snackbar for long period and allow user to easily undo changes.