### PR TITLE
fixed gradle dependencies to make project compilable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
         - platform-tools
         - tools
 
-        - build-tools-23.0.1
+        - build-tools-28.0.3
 
         - android-23
         

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         }
     }
     compileSdkVersion 23
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '25.0.3'
     defaultConfig {
         applicationId "com.avjindersinghsekhon.minimaltodo"
         minSdkVersion 16

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         }
     }
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "com.avjindersinghsekhon.minimaltodo"
         minSdkVersion 16

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,6 @@ android {
         }
     }
     compileSdkVersion 23
-    buildToolsVersion '25.0.3'
     defaultConfig {
         applicationId "com.avjindersinghsekhon.minimaltodo"
         minSdkVersion 16

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,9 @@
 buildscript {
     repositories {
         jcenter()
-        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.google.gms:google-services:1.3.0-beta1'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -14,8 +13,24 @@ buildscript {
     }
 }
 
+buildscript {
+    repositories {
+        mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
+        google()
+    }
+    dependencies {
+        classpath 'com.jakewharton:butterknife-gradle-plugin:8.5.1'
+    }
+}
+
+
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 06 14:47:31 GMT 2018
+#Tue Nov 06 17:37:41 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
- This project was not compiling in Android Studio 3.2.1, this fix makes codebase compile in recent version of Android Studio
- buildToolVersion is updated to 28.0.3, this string is removed from app/build.gradle as it is no longer required by updated SDK
- Gradle build tool version is changed to 3.2.1
- Gradle version is updated to 4.6