### PR TITLE
fix 142: Empty list Linear Layout is not in center

### DIFF
--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,8 +1,6 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_width="match_parent"
-              android:orientation="vertical"
-              android:gravity="center"
               android:layout_height="match_parent">
 
     <!--<include layout="@layout/base_toolbar"/>-->
@@ -64,4 +62,4 @@
 
 
     </android.support.design.widget.CoordinatorLayout>
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
Fix: #142 

Fixed the layout

**Screenshots**

![fix - empty list layout not in center](https://user-images.githubusercontent.com/30969403/77427759-f05c7a00-6dfc-11ea-857b-75969c780821.jpg)
